### PR TITLE
モデル削除時の処理を修正

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -71,9 +71,9 @@ module Palette
 
         # @note for soft delete
         after_destroy :delete_document
-        
+
         def delete_document
-          self.__elasticsearch__.delete_document
+          self.__elasticsearch__.delete_document rescue nil
         end
 
         index_name { "#{Rails.env.downcase.underscore}_#{self.connection.current_database}_#{self.table_name.underscore}" }


### PR DESCRIPTION
## 概要
・検索サーバーにデータがない状態でモデルの削除処理が行われると、検索サーバーのデータの削除に失敗し、モデルの削除処理自体も失敗してしまうので修正する

・コールバックで `destroy` を呼んでいるところで `rescue nil` する。( 公式では `delete_document` を呼んでいるっぽい)