### PR TITLE
INDEX更新中の新規レコードを同期する

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -30,15 +30,14 @@ module Palette
           current_indices.first
         end
 
-        def indexing_process
-          self.__elasticsearch__.client.indices.create index: new_index_name,
+        def indexing_process(index_name)
+          self.__elasticsearch__.client.indices.create index: index_name,
                                                        body: {
                                                          settings: self.settings.to_hash,
                                                          mappings: self.mappings.to_hash
                                                        }
-
           process_started_at = Time.current
-          self.__elasticsearch__.import(index: new_index_name)
+          self.__elasticsearch__.import(index: index_name)
           process_end_at = Time.current
 
           # @note for new records generated while indexing
@@ -48,7 +47,7 @@ module Palette
               previous_end_at = process_end_at
               process_started_at = Time.current
               # @see https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/importing.rb
-              self.__elasticsearch__.import(index: new_index_name) query: -> { where(updated_at: previous_started_at..previous_end_at) }
+              self.__elasticsearch__.import(index: index_name, query: -> { where(updated_at: previous_started_at..previous_end_at) })
               process_end_at = Time.current
               break if self.where(updated_at: process_started_at..process_end_at).empty?
             end
@@ -57,8 +56,7 @@ module Palette
 
         def create_index!
           new_index_name = get_new_index_name
-          indexing_process
-
+          indexing_process(new_index_name)
           self.__elasticsearch__.client.indices.update_aliases body: {
             actions: [
               { add: { index: new_index_name, alias: self.index_name } }
@@ -69,8 +67,7 @@ module Palette
         def reindex!
           new_index_name = get_new_index_name
           old_index_name = get_old_index_name
-          indexing_process
-
+          indexing_process(new_index_name)
           self.__elasticsearch__.client.indices.update_aliases body: {
             actions: [
               { remove: { index: old_index_name, alias: self.index_name } },
@@ -90,7 +87,7 @@ module Palette
         after_destroy :delete_document
 
         def delete_document
-          self.__elasticsearch__.delete_document
+          self.__elasticsearch__.delete_document rescue nil
         end
 
         index_name { "#{Rails.env.downcase.underscore}_#{self.connection.current_database}_#{self.table_name.underscore}" }

--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -30,8 +30,7 @@ module Palette
           current_indices.first
         end
 
-        def create_index!
-          new_index_name = get_new_index_name
+        def indexing_process
           self.__elasticsearch__.client.indices.create index: new_index_name,
                                                        body: {
                                                          settings: self.settings.to_hash,
@@ -54,6 +53,11 @@ module Palette
               break if self.where(updated_at: process_started_at..process_end_at).empty?
             end
           end
+        end
+
+        def create_index!
+          new_index_name = get_new_index_name
+          indexing_process
 
           self.__elasticsearch__.client.indices.update_aliases body: {
             actions: [
@@ -65,28 +69,7 @@ module Palette
         def reindex!
           new_index_name = get_new_index_name
           old_index_name = get_old_index_name
-          self.__elasticsearch__.client.indices.create index: new_index_name,
-                                                       body: {
-                                                         settings: self.settings.to_hash,
-                                                         mappings: self.mappings.to_hash
-                                                       }
-
-          process_started_at = Time.current
-          self.__elasticsearch__.import(index: new_index_name)
-          process_end_at = Time.current
-
-          # @note for new records generated while indexing
-          unless self.where(updated_at: process_started_at..process_end_at).empty?
-            loop do
-              previous_started_at = process_started_at
-              previous_end_at = process_end_at
-              process_started_at = Time.current
-              # @see https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/importing.rb
-              self.__elasticsearch__.import(index: new_index_name) query: -> { where(updated_at: previous_started_at..previous_end_at) }
-              process_end_at = Time.current
-              break if self.where(updated_at: process_started_at..process_end_at).empty?
-            end
-          end
+          indexing_process
 
           self.__elasticsearch__.client.indices.update_aliases body: {
             actions: [

--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -41,16 +41,13 @@ module Palette
           process_end_at = Time.current
 
           # @note for new records generated while indexing
-          unless self.where(updated_at: process_start_at..process_end_at).empty?
-            loop do
-              previous_start_at = process_start_at
-              previous_end_at = process_end_at
-              process_start_at = Time.current
-              # @see https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/importing.rb
-              self.__elasticsearch__.import(index: new_index_name, query: -> { where(updated_at: previous_start_at..previous_end_at) })
-              process_end_at = Time.current
-              break if self.where(updated_at: process_start_at..process_end_at).empty?
-            end
+          loop do
+            break if self.where(updated_at: process_start_at..process_end_at).empty?
+            previous_start_at = process_start_at
+            process_start_at = Time.current
+            # @see https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/importing.rb
+            self.__elasticsearch__.import(index: new_index_name, query: -> { where(updated_at: previous_start_at..Time.current) })
+            process_end_at = Time.current
           end
         end
 

--- a/lib/tasks/palette/elastic_search.rake
+++ b/lib/tasks/palette/elastic_search.rake
@@ -6,12 +6,7 @@ namespace :palette do
 
         if ENV['CLASS'].present? && (model = ENV['CLASS'].constantize).present?
           # update only specified model's index
-          loop do
-            final_record_updated_at = model.order(updated_at: :desc).first&.updated_at
-            res = model.update_elasticsearch_index!
-            # @note INDEX更新時に作成されたデータ(対象モデル)は同期されないため、最後のレコード更新時間がINDEX更新処理前後で変わっていた場合、更新処理をくり返す
-            break if final_record_updated_at == model.order(updated_at: :desc).first&.updated_at
-          end
+          res = model.update_elasticsearch_index!
           Rails.logger.info res
         elsif ENV['CLASS'].present? && (model = ENV['CLASS'].constantize).blank?
           Rails.logger.error "ENV['CLASS'] is not found"
@@ -23,12 +18,7 @@ namespace :palette do
           models = ObjectSpace.each_object(Class).select{ |s| s.ancestors.include?(ActiveRecord::Base) && s.respond_to?(:__elasticsearch__) }
           models.each do |model|
             Rails.logger.info "update index of #{model.name}"
-            loop do
-              final_record_updated_at = model.order(updated_at: :desc).first&.updated_at
-              res = model.update_elasticsearch_index!
-              # @note INDEX更新時に作成されたデータ(対象モデル)は同期されないため、最後のレコード更新時間がINDEX更新処理前後で変わっていた場合、更新処理をくり返す
-              break if final_record_updated_at == model.order(updated_at: :desc).first&.updated_at
-            end
+            res = model.update_elasticsearch_index!
             Rails.logger.info res
           end
 


### PR DESCRIPTION
## 概要
- 更新中に新規に作成されたデータを同期する処理を追加する
- `update_index!`を実行開始から実行終了までの間に新規にレコードが作成された場合、新規作成されたレコードもESに同期されるようにする

## 現状の詳細(調査結果)
INDEX更新中に手動でデータを作成してみたところの報告。(ログを参照しながら実験)
- 該当のモデルの更新中 → 同期されてない
- 該当のモデル以外の更新中 → 同期されている
(具体例：更新中に`Cms::Branch`を追加した場合、`AnnouncementV2::Message`などの更新中は問題なく同期されるが、`Cms::Branch`の更新中は同期されない)

## 方針
各モデルごとで最後のレコード更新時間がINDEX更新処理前後で変わっていた場合、更新処理をくり返す