### PR TITLE
Integerの検索に対応させる

### DIFF
--- a/lib/palette/elastic_search/query_factory.rb
+++ b/lib/palette/elastic_search/query_factory.rb
@@ -23,6 +23,8 @@ module Palette
                 query_partial = query_partial_for((attributes[attr]).to_s, field)
               when :full_match_with_analyzer
                 query_partial = full_match_for((attributes[attr]).to_s, field, query_pattern[:analyzer])
+              when :integer
+                query_partial = integer_for(attributes, field)
               when :geo_point
                 geo_point_query = geo_point_for(attributes)
               when :date
@@ -103,6 +105,18 @@ module Palette
               return {}
           end
         end
+        
+
+        # for integer query
+        #
+        # @params [Object] attributes
+        # @params [Symbol] field
+        # @return [Hash]
+        def integer_for(attributes, field)
+          attributes = attributes.symbolize_keys
+          field = field.to_sym
+          return { term: { field => attributes[field] } }
+        end
 
         # for nested query
         #
@@ -142,6 +156,9 @@ module Palette
           @mappings_hashes.keys.each do |index|
             if type_by(index, field, should_nested).present? && type_by(index, field, should_nested) == :date
               return { pattern: 'date' }
+            end
+            if type_by(index, field, should_nested).present? && type_by(index, field, should_nested) == :integer
+              return { pattern: 'integer'}
             end
             if type_by(index, field, should_nested).present? && type_by(index, field, should_nested) == :nested
               return { pattern: 'nested' }

--- a/spec/palette/elastic_search_spec.rb
+++ b/spec/palette/elastic_search_spec.rb
@@ -133,11 +133,11 @@ RSpec.describe Palette::ElasticSearch do
       end
     end
 
-    context 'full_match' do
+    context 'integer' do
       let(:field) { :age }
-      it 'full_match is returned' do
+      it 'integer is returned' do
         res = ::Palette::ElasticSearch::QueryFactory.send(:get_query_pattern, field)
-        expect(res[:pattern]).to eq('full_match_with_analyzer')
+        expect(res[:pattern]).to eq('integer')
       end
     end
   end

--- a/spec/user.rb
+++ b/spec/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
     mapping _source: { enabled: true }, _all: { enabled: true }, dynamic: false do
       indexes :name, type: 'string', analyzer: 'bigram'
       indexes :sex, analyzer: 'keyword_analyzer'
-      indexes :age, analyzer: 'keyword_analyzer'
+      indexes :age, type: 'integer'
       indexes :address, type: 'string', analyzer: 'bigram'
       indexes :phone_numbers, type: 'nested' do
         indexes :number, analyzer: 'keyword_analyzer'


### PR DESCRIPTION
## What

いままで数値の検索は完全マッチで行っていたので、数値の検索を行うようにする
[関連](https://github.com/machikoe/palette/pull/3370)

1.  `PushV2::Message` のsettingsの変更 + お知らせ作成
2. 配信 `announcement:update` とか
3. elasticsearchのindexのupdate

した後確認したところ正常に動作しました
検索用のjsonも期待通りのものが作成されました