### PR TITLE
前方一致検索で単語をハイフンで区切らない

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -164,7 +164,7 @@ module Palette
                          },
                          autocomplete_analyzer: {
                            type: 'custom',
-                           tokenizer: 'standard',
+                           tokenizer: 'whitespace',
                            filter: %W(lowercase autocomplete_filter)
                          }
                        },

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,5 +1,5 @@
 module Palette
   module ElasticSearch
-    VERSION = "0.2.2"
+    VERSION = "0.2.2.1"
   end
 end


### PR DESCRIPTION
### 問題

前方一致において、

```
12345-67890
```

というデータがあったときに、

`123` でも `678` でもマッチしてしまっていた。

---

### 対応内容

ハイフンを含む場合の挙動を調整するため analyzer を修正します。

---

### その他

バージョンについては `0.2.2.1` で設定しています。