### PR TITLE
中黒等を区切り文字ではなくす

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -143,7 +143,7 @@ module Palette
                            type: 'ngram',
                            min_gram: 1,
                            max_gram: 20,
-                           token_chars: %W(letter digit)
+                           token_chars: %W(letter digit punctuation)
                          }
                        },
                        analyzer: {

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,5 +1,5 @@
 module Palette
   module ElasticSearch
-    VERSION = "0.4.4"
+    VERSION = "0.4.5"
   end
 end


### PR DESCRIPTION
## 概要
elasticsearchの検索について修正する

## 関連URL
https://github.com/machikoe/palette/issues/4314
https://github.com/machikoe/palette/pull/4432

## 修正内容
n_gramのtoken_charsにpunctuationを追加することで中黒やハイフンの使用を可能にする