### PR TITLE
space_trimmer作成

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -165,11 +165,11 @@ module Palette
                          },
                          bigram: {
                            tokenizer: 'bi_gram',
-                           char_filter: %W(my_icu_normalizer)
+                           char_filter: %W(my_icu_normalizer space_trimmer)
                          },
                          ngram: {
                            tokenizer: 'n_gram',
-                           char_filter: %W(my_icu_normalizer)
+                           char_filter: %W(my_icu_normalizer space_trimmer)
                          },
                          katakana: {
                            tokenizer: 'whitespace',
@@ -240,7 +240,12 @@ module Palette
                            type: 'pattern_replace',
                            pattern: '[\x{30FC}\x{2010}-\x{2015}\x{2212}\x{FF70}-]',
                            replacement: ''
-                         }
+                         },
+                         space_trimmer: {
+                          type: 'pattern_replace',
+                          pattern: '[\s]',
+                          replacement: ''
+                        }
                        }
                      }
                    }

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,5 +1,5 @@
 module Palette
   module ElasticSearch
-    VERSION = "0.4.5"
+    VERSION = "0.4.6"
   end
 end


### PR DESCRIPTION
ngram及びbigramについて、半角全角スペース、改行、タブ等を取り除くfilterを作成した。
これにより、"汎用　太郎"と入力すると、"汎用太郎"として登録される。