### PR TITLE
elasticsearchの更新タスクで新しいレコードの更新ループが止まらない修正

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -40,19 +40,7 @@ module Palette
                                                          settings: self.settings.to_hash,
                                                          mappings: self.mappings.to_hash
                                                        }
-          process_start_at = Time.current
           self.__elasticsearch__.import(index: new_index_name, query: options[:query])
-          process_end_at = Time.current
-
-          # @note for new records generated while indexing
-          loop do
-            break if self.where(updated_at: process_start_at..process_end_at).empty?
-            previous_start_at = process_start_at
-            process_start_at = Time.current
-            # @see https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/importing.rb
-            self.__elasticsearch__.import(index: new_index_name, query: -> { where(updated_at: previous_start_at..Time.current) })
-            process_end_at = Time.current
-          end
         end
 
         def create_index!(options={})
@@ -68,13 +56,26 @@ module Palette
         def reindex!(options={})
           new_index_name = get_new_index_name
           old_index_name = current_indices.sort.last
+
+          process_start_at = Time.current
           indexing(new_index_name, options)
+          process_end_at = Time.current
+
           self.__elasticsearch__.client.indices.update_aliases body: {
             actions: [
               { remove: { index: old_index_name, alias: self.index_name } },
               { add: { index: new_index_name, alias: self.index_name } }
             ]
           }
+
+          self.where(updated_at: (process_start_at..process_end_at)).find_each do |record|
+            begin
+              record.__elasticsearch__.update_document
+            rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+              record.__elasticsearch__.index_document
+            end
+          end
+
           self.__elasticsearch__.client.indices.delete index: old_index_name rescue nil
         end
 

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,5 +1,5 @@
 module Palette
   module ElasticSearch
-    VERSION = "0.4.5"
+    VERSION = "0.4.6"
   end
 end


### PR DESCRIPTION
## 概要
`lib/palette/elastic_search/searchable.rb` のindexingメソッドを回しているときに、その最中に生成されるレコード用に更新するループが止まらないことがあったので、修正しました

## 関連URL
https://github.com/machikoe/palette/issues/4586
https://github.com/machikoe/palette/pull/4636