### PR TITLE
Elasticsearch::Transport::Transport::Errors::Conflict対応

### DIFF
--- a/lib/palette/elastic_search/indexing.rb
+++ b/lib/palette/elastic_search/indexing.rb
@@ -16,7 +16,7 @@ module Palette
 
         def palette_update_document
           begin
-            update_document
+            update_document(retry_on_conflict: 1)
           rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
             palette_index_document
           rescue ::Elasticsearch::Transport::Transport::Errors::Conflict => e

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,5 +1,5 @@
 module Palette
   module ElasticSearch
-    VERSION = "0.4.9"
+    VERSION = "0.4.10"
   end
 end


### PR DESCRIPTION
## 概要
発生していた `Elasticsearch::Transport::Transport::Errors::Conflict` の対応をしました。

## 検証
ecs上にデプロイしたpaletteのdeviceのapiにリクエストを送り、エラーが出なくなることを確認しました、10並列で以下のスクリプトを実行するといった規模では `retry_on_conflict` を1回行えばエラーがなくなりましたので、1回に設定してあります
### リクエストを送るシェルスクリプト
```
#!/usr/bin/bash
declare -i COUNTER
COUNTER=0
while [ "$COUNTER" -lt 500 ]
do
curl -X POST -H "Accept: application/json" -H "Content-Type: application/json" -H "X-Palette-Device-Code: 1" https://dummy-qa4.palette.cloud/api/v2/devices -d '{"app_uid": "cloud.palette.dummy", "registration_token": "84d138b3-e809-4437-9592-202f5195e589", "client_type": "ios", "name": "iPhoneX", "app_version": "1.0.0", "os_version": "iOS12"}'
let COUNTER++
done
```

### 発生していたエラー(対応内容)
```
E, [2019-10-03T01:43:07.114687 #1] ERROR -- : [409]
{
    "error": {
        "root_cause": [
            {
                "type": "version_conflict_engine_exception",
                "reason": "[device][1]: version conflict, current version [438] is different than the one provided [437]",
                "index_uuid": "WQUqu7iFS2uyaUBoxZuJOA",
                "shard": "0",
                "index": "qa_qa_dummy_devices_20190906_211755"
            }
        ],
        "type": "version_conflict_engine_exception",
        "reason": "[device][1]: version conflict, current version [438] is different than the one provided [437]",
        "index_uuid": "WQUqu7iFS2uyaUBoxZuJOA",
        "shard": "0",
        "index": "qa_qa_dummy_devices_20190906_211755"
    },
    "status": 409
}
```

## 関連url
https://github.com/machikoe/palette/issues/4320