### PR TITLE
circle_ci設定

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,11 @@ echo-tag: &echo-tag
   run:
     name: Echo Tag
     command: |
-      echo "${CIRCLE_TAG} test"
+      # test="${CIRCLE_TAG%.*}"
+      # test+="$((${CIRCLE_TAG##*.} + 1))"
+      TEST_TAG="v0.4.10"
+      test="${TEST_TAG%.*}"
+      test+="$((${TEST_TAG##*.} + 1))"
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,13 @@ run-rspec: &run-rspec
         --format progress \
         -- ${TESTFILES}
 
-tag-setting: &tag-setting
+version-setting: &version-setting
   run:
     name: Release Tag
     command: |
-      # 手動で変更した場合はmerge時messageに[tag-release]をつける
+      # 手動で変更した場合はmerge時messageに[tag release]をつける
       commitmessage=$(git log --pretty=%B -n 1)
-      if [[ $commitmessage = *"[tag-release]"* ]]; then
+      if [[ $commitmessage = *"[tag release]"* ]]; then
         NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
         # 環境変数として設定する必要あり
         git config user.name $GIT_USER_NAME
@@ -68,7 +68,7 @@ tag-setting: &tag-setting
         git config user.name $GIT_USER_NAME
         git config user.email $GIT_USER_EMAIL
         git add lib/palette/elastic_search/version.rb
-        git commit -m "[tag-release] version up"
+        git commit -m "[tag release] version up"
         git push origin master
       fi
 
@@ -109,7 +109,7 @@ release-tag: &release-tag
     - checkout
     - *restore_checkout_cache
     - *restore_bundle_cache
-    - *tag-setting
+    - *version-setting
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,29 +42,27 @@ version-setting: &version-setting
   run:
     name: Version Setting
     command: |
-      # # 手動で変更した場合はmerge時messageに[tag release]をつける
-      # commitmessage=$(git log --pretty=%B -n 1)
-      # if [[ $commitmessage = *"[tag release]"* ]]; then
-      #   NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      #   # 環境変数として設定する必要あり
-      #   git config user.name $GIT_USER_NAME
-      #   git config user.email $GIT_USER_EMAIL
-      #   git tag $NEW_TAG
-      #   git push origin $NEW_TAG
-      # else
-      #   OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      #   NEW_TAG="${OLD_TAG%.*}"
-      #   NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      #   ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-      #   echo $ALL_TEXT > lib/palette/elastic_search/version.rb
-      #   git config user.name $GIT_USER_NAME
-      #   git config user.email $GIT_USER_EMAIL
-      #   git add lib/palette/elastic_search/version.rb
-      #   git commit -m "[tag release] version up"
-      #   git push origin master
-      # fi
-      git config -l
-      git log --pretty=%B -n 1
+      # 手動で変更した場合はmerge時messageに[tag release]をつける
+      commitmessage=$(git log --pretty=%B -n 1)
+      if [[ $commitmessage = *"[tag release]"* ]]; then
+        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        # 環境変数として設定する必要あり
+        git config user.name $GIT_USER_NAME
+        git config user.email $GIT_USER_EMAIL
+        git tag $NEW_TAG
+        git push origin $NEW_TAG
+      else
+        OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        NEW_TAG="${OLD_TAG%.*}"
+        NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+        ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+        echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+        git config user.name $GIT_USER_NAME
+        git config user.email $GIT_USER_EMAIL
+        git add lib/palette/elastic_search/version.rb
+        git commit -m "[tag release] version up"
+        git push origin master
+      fi
 
 rspec-test: &rspec-test
   steps:
@@ -106,3 +104,6 @@ workflows:
       - tag-release:
           requires:
             - test-rspec
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,28 @@ tag-setting: &tag-setting
       git tag $NEW_TAG
       git push origin $NEW_TAG
 
+      # # version.rbを自動変更する場合
+      # # (メジャーバージョンは"手動変更かつmerge時commitに[tag-release]"または"マイナーバージョンを-1で設定"が必要)
+      # commitmessage=$(git log --pretty=%B -n 1)
+      # if [[ $commitmessage = *"[tag-release]"* ]]; then
+      #   NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      #   git config user.name $GIT_USER_NAME
+      #   git config user.email $GIT_USER_EMAIL
+      #   git tag $NEW_TAG
+      #   git push origin $NEW_TAG
+      # else
+      #   OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      #   NEW_TAG="${OLD_TAG%.*}"
+      #   NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+      #   ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+      #   echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+      #   git config user.name $GIT_USER_NAME
+      #   git config user.email $GIT_USER_EMAIL
+      #   git add lib/palette/elastic_search/version.rb
+      #   git commit -m "[tag-release]"
+      #   git push origin master
+      # fi
+
 setting-build: &setting-build
   steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,16 +40,15 @@ run-rspec: &run-rspec
         --format progress \
         -- ${TESTFILES}
 
-echo-tag: &echo-tag
+chenge-tag: &echo-tag
   run:
     name: Echo Tag
     command: |
-      # test="${CIRCLE_TAG%.*}"
-      # test+="$((${CIRCLE_TAG##*.} + 1))"
-      TEST_TAG="v0.4.10"
-      TEST="${TEST_TAG%.*}"
-      TEST+="$((${TEST_TAG##*.} + 1))"
-      echo "${TEST}"
+      # NEW_TAG="${CIRCLE_TAG%.*}"
+      # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
+      # git tag $NEW_TAG
+      # git push origin $NEW_TAG
+      echo "test"
 
 setting-build: &setting-build
   steps:
@@ -107,3 +106,6 @@ workflows:
       - tag-setting:
           requires:
             - test-rspec
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ tag-setting: &tag-setting
 setting-build: &setting-build
   steps:
     - checkout
-    - *bundler-install
     - save_cache:
         key: *checkout_cache_key
         paths: *working_directory
@@ -115,11 +114,11 @@ release-tag: &release-tag
 version: 2
 jobs:
   build-setting:
-    <<: [*defaults, *deps-images]
+    <<: [*defaults, *deps-images, *bundler-install]
     <<: *setting-build
 
   test-rspec:
-    <<: [*defaults, *deps-images]
+    <<: [*defaults, *deps-images, *bundler-install]
     <<: *rspec-test
 
   tag-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'circleci/ruby:2.7.0-node-browsers'
+    - image: 'circleci/ruby:2.6.0-node-browsers'
       environment:
         TZ: Asia/Tokyo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,16 +40,18 @@ run-rspec: &run-rspec
         --format progress \
         -- ${TESTFILES}
 
-chenge-tag: &echo-tag
+tag-setting: &tag-setting
   run:
-    name: Echo Tag
+    name: Release Tag
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      git log
+      git config user.email "akutoyuuki@gmail.com"
+      git config user.name "rei-akuto"
       git config -l
+      git log
 
 setting-build: &setting-build
   steps:
@@ -78,9 +80,9 @@ rspec-test: &rspec-test
         path: test-results
         destination: test-results
 
-setting-tag: &setting-tag
+release-tag: &release-tag
   steps:
-    - *echo-tag
+    - *tag-setting
 
 version: 2
 jobs:
@@ -92,9 +94,9 @@ jobs:
     <<: [*defaults, *deps-images]
     <<: *rspec-test
 
-  tag-setting:
+  tag-release:
     <<: [*defaults, *deps-images]
-    <<: *setting-tag
+    <<: *release-tag
 
 workflows:
   version: 2
@@ -104,7 +106,7 @@ workflows:
       - test-rspec:
           requires:
             - build-setting
-      - tag-setting:
+      - tag-release:
           requires:
             - test-rspec
           # filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,16 @@ deps-images: &deps-images
       environment:
         TZ: Asia/Tokyo
 
+bundler-install: &bundler-install
+  run:
+    name: Bundler install
+    command: |
+      gem install bundler
+
 bundle-install: &bundle-install
   run:
     name: Bundle install
     command: |
-      gem install bundler
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
 bundle_cache_key: &bundle_cache_key bundle-v3-{{ checksum "Gemfile.lock" }}
@@ -72,6 +77,7 @@ tag-setting: &tag-setting
 setting-build: &setting-build
   steps:
     - checkout
+    - *bundler-install
     - save_cache:
         key: *checkout_cache_key
         paths: *working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - test-rspec:
+      - test-rspec
       - tag-release:
           requires:
             - test-rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
-      git clone git@github.com:rei-akuto/palette-elastic_search.git
       cd palette-elastic_search
       # git tag $NEW_TAG
       # git push origin $NEW_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ deps-images: &deps-images
       environment:
         TZ: Asia/Tokyo
 
-bundler-install: &bundler-install
+install-bundler: &install-bundler
   run:
-    name: Bundler install
+    name: gem Install Bundler
     command: |
       gem install bundler
 
@@ -48,7 +48,7 @@ run-rspec: &run-rspec
 
 version-setting: &version-setting
   run:
-    name: Release Tag
+    name: Version Setting
     command: |
       # 手動で変更した場合はmerge時messageに[tag release]をつける
       commitmessage=$(git log --pretty=%B -n 1)
@@ -79,7 +79,7 @@ setting-build: &setting-build
         key: *checkout_cache_key
         paths: *working_directory
     - *restore_bundle_cache
-    - *bundler-install
+    - *install-bundler
     - *bundle-install
     - save_cache:
         key: *bundle_cache_key
@@ -93,7 +93,7 @@ rspec-test: &rspec-test
     - checkout
     - *restore_checkout_cache
     - *restore_bundle_cache
-    - *bundler-install
+    - *install-bundler
     - *bundle_path
     - *run-rspec
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,5 +82,5 @@ workflows:
     jobs:
       - build-setting
       - test-rspec:
-        requires:
-          - build-setting
+          requires:
+            - build-setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ bundle-install: &bundle-install
     command: |
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
-bundle_cache_key: &bundle_cache_key bundle-v2-{{ checksum "Gemfile.lock" }}
+bundle_cache_key: &bundle_cache_key bundle-v1-{{ checksum "Gemfile.lock" }}
 restore_bundle_cache: &restore_bundle_cache
   restore_cache:
     key: *bundle_cache_key
@@ -58,6 +58,7 @@ rspec-test: &rspec-test
     - *restore_checkout_cache
     - *restore_bundle_cache
     - *bundle_path
+    - *bundle-install
     - *run-rspec
     - store_test_results:
         path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,14 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
+      # git clone git@github.com:rei-akuto/palette-elastic_search.git
+      # cd palette-elastic_search
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      # git config user.name = $CIRCLE_PR_USERNAME
-      # git config user.email = 
+      git config user.name = $GIT_USER_NAME
+      git config user.email = $GIT_USER_EMAIL
+      echo $GIT_USER_NAME
+      echo $GIT_USER_EMAIL
       git config -l
 
 setting-build: &setting-build
@@ -64,6 +68,7 @@ setting-build: &setting-build
         key: *bundle_cache_key
         paths:
           - vendor/bundle
+
 rspec-test: &rspec-test
   steps:
     - attach_workspace:
@@ -107,6 +112,7 @@ workflows:
             - build-setting
       - tag-release:
           requires:
+            - build-setting
             - test-rspec
           # filters:
           #   branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,9 @@ tag-setting: &tag-setting
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      git --version
+      # git config user.name = $CIRCLE_PR_USERNAME
+      # git config user.email = 
+      git config -l
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
-      git clone git@github.com:machikoe/palette-elastic_search.git
-      cd palette-elastic_search
+      # git clone git@github.com:machikoe/palette-elastic_search.git
+      # cd palette-elastic_search
       # git config user.name=$GIT_USER_NAME
       # git config user.email=$GIT_USER_EMAIL
       # git tag $NEW_TAG
@@ -92,6 +92,15 @@ rspec-test: &rspec-test
 
 release-tag: &release-tag
   steps:
+    - attach_workspace:
+        at: .
+    - checkout
+    - run: pwd
+    - run: ls
+    - *restore_checkout_cache
+    - *restore_bundle_cache
+    - run: pwd
+    - run: ls
     - *skip-ssh-command
     - *tag-setting
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'quay.io/palettecloud/ruby-cron:v2.4.7'
+    - image: 'circleci/node:10.15.0-stretch-browsers'
       environment:
         TZ: Asia/Tokyo
 
@@ -46,15 +46,15 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
-      # git clone git@github.com:rei-akuto/palette-elastic_search.git
-      # cd palette-elastic_search
+      git clone git@github.com:rei-akuto/palette-elastic_search.git
+      cd palette-elastic_search
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
       # git config user.name=$GIT_USER_NAME
       # git config user.email=$GIT_USER_EMAIL
-      echo $GIT_USER_NAME
-      echo $GIT_USER_EMAIL
       git branch -a
+      git config -l
+
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,12 @@ run-rspec: &run-rspec
         --format progress \
         -- ${TESTFILES}
 
+echo-tag: &echo-tag
+  run:
+    name: Echo Tag
+    command: |
+      echo ${CIRCLE_TAG}
+
 setting-build: &setting-build
   steps:
     - checkout
@@ -67,6 +73,10 @@ rspec-test: &rspec-test
         path: test-results
         destination: test-results
 
+setting-tag: &setting-tag
+  steps:
+    - *echo-tag
+
 version: 2
 jobs:
   build-setting:
@@ -77,6 +87,9 @@ jobs:
     <<: [*defaults, *deps-images]
     <<: *rspec-test
 
+  tag-setting:
+    <<: [*defaults, *deps-images]
+    <<: *setting-tag
 
 workflows:
   version: 2
@@ -86,3 +99,6 @@ workflows:
       - test-rspec:
           requires:
             - build-setting
+      - tag-setting:
+          requires:
+            - test-rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,9 @@ tag-setting: &tag-setting
       NEW_TAG=v${VERSION}
       echo $NEW_TAG
       # 環境変数として設定する必要あり
-      # git config user.name $GIT_USER_NAME
-      # git config user.email $GIT_USER_EMAIL
+      git config user.name $GIT_USER_NAME
+      git config user.email $GIT_USER_EMAIL
+      git config -l
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ run-rspec: &run-rspec
       bundle exec rspec --profile 10 \
         --format RspecJunitFormatter \
         --out test-results/rspec/results_${CIRCLE_NODE_INDEX}.xml \
-        --format progress
+        --format progress \
+        -- .
 
 version-setting: &version-setting
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ bundle-install: &bundle-install
   run:
     name: Bundle install
     command: |
+      gem install bundler
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
 bundle_cache_key: &bundle_cache_key bundle-v3-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,10 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
-      # git clone git@github.com:rei-akuto/palette-elastic_search.git
-      # cd palette-elastic_search
+      git clone git@github.com:rei-akuto/palette-elastic_search.git
+      cd palette-elastic_search
+      ls
+      pwd
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
       git config user.name = $GIT_USER_NAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-defaults: &defaluts
+defaults: &defaults
   working_directory: &working_directory
     ~/palette-elastic_search
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'circleci/node:10.15.0-stretch-browsers'
+    - image: 'circleci/ruby:2.7.0-node-browsers-legacy'
       environment:
         TZ: Asia/Tokyo
 
@@ -14,7 +14,7 @@ bundle-install: &bundle-install
     command: |
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
-bundle_cache_key: &bundle_cache_key bundle-v3-{{ checksum "Gemfile.lock" }}
+bundle_cache_key: &bundle_cache_key bundle-v1-{{ checksum "Gemfile.lock" }}
 restore_bundle_cache: &restore_bundle_cache
   restore_cache:
     key: *bundle_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ bundle-install: &bundle-install
     command: |
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
-bundle_cache_key: &bundle_cache_key bundle-v3-{{ checksum "Gemfile.lock" }}
+bundle_cache_key: &bundle_cache_key bundle-v1-{{ checksum "Gemfile.lock" }}
 restore_bundle_cache: &restore_bundle_cache
   restore_cache:
     key: *bundle_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ rspec-test: &rspec-test
     - *restore_checkout_cache
     - *restore_bundle_cache
     - *bundle_path
+    # restore_bundle_cacheができるまでの実験用
     - *bundle-install
     - *run-rspec
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,8 @@ tag-setting: &tag-setting
   run:
     name: Release Tag
     command: |
-      VERSION=$(grep -e V lib/palette/elastic_search/version.rb)
-      arr=(`echo $VERSION`)
-      NEW_TAG=v${arr[2]}
+      VERSION=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      NEW_TAG=v${VERSION}
       echo $NEW_TAG
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,23 @@ tag-setting: &tag-setting
       VERSION=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
       NEW_TAG=v${VERSION}
       echo $NEW_TAG
+      # git config user.name $GIT_USER_NAME
+      # git config user.email $GIT_USER_EMAIL
+      # git tag $NEW_TAG
+      # git push origin $NEW_TAG
 
       # file自体書き換える場合
       OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
       NEW_TAG="${OLD_TAG%.*}"
       NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      OLD_TEXT=$(grep -e V lib/palette/elastic_search/version.rb)
-      NEW_TEXT=`echo $ALL_TEXT | sed s/$OLD_TAG/$NEW_TAG/g`
-      ALL_TEXT=$(sed s/$TEXT/$NEW_TEXT/ lib/palette/elastic_search/version.rb)
+      ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
       echo $ALL_TEXT
       # echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+      # git config user.name $GIT_USER_NAME
+      # git config user.email $GIT_USER_EMAIL
       # git add lib/palette/elastic_search/version.rb
       # git commit -m "version up"
       # git push origin master
-      # git tag $NEW_TAG
-      # git push origin $NEW_TAG
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,12 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
+      git clone git@github.com:machikoe/palette-elastic_search.git
       cd palette-elastic_search
-      # git tag $NEW_TAG
-      # git push origin $NEW_TAG
       # git config user.name=$GIT_USER_NAME
       # git config user.email=$GIT_USER_EMAIL
-      git branch -a
+      # git tag $NEW_TAG
+      # git push origin $NEW_TAG
       git config -l
 
 skip-ssh-command: &skip-ssh-command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ setting-build: &setting-build
 rspec-test: &rspec-test
   steps:
     - attach_workspace:
-      at: .
+        at: .
     - checkout
     - *restore_checkout_cache
     - *restore_bundle_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,14 +53,7 @@ tag-setting: &tag-setting
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
       git config -l
-
-skip-ssh-command: &skip-ssh-command
-  run:
-    name: Skip ssh Command
-    command: |
-      mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-      
-
+      git branch -a
 
 setting-build: &setting-build
   steps:
@@ -95,13 +88,8 @@ release-tag: &release-tag
     - attach_workspace:
         at: .
     - checkout
-    - run: pwd
-    - run: ls
     - *restore_checkout_cache
     - *restore_bundle_cache
-    - run: pwd
-    - run: ls
-    - *skip-ssh-command
     - *tag-setting
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'circleci/ruby:2.6.0-node-browsers'
+    - image: 'circleci/ruby:2.6.0'
       environment:
         TZ: Asia/Tokyo
 
@@ -20,14 +20,8 @@ bundle-install: &bundle-install
     command: |
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
-bundle_cache_key: &bundle_cache_key bundle-v1-{{ checksum "Gemfile.lock" }}
-restore_bundle_cache: &restore_bundle_cache
-  restore_cache:
-    key: *bundle_cache_key
-
 bundle_path: &bundle_path
   run: bundle --path vendor/bundle
-    
 
 checkout_cache_key: &checkout_cache_key v1-repo-{{ .Environment.CIRCLE_SHA1 }}
 restore_checkout_cache: &restore_checkout_cache
@@ -39,62 +33,47 @@ run-rspec: &run-rspec
     name: Run Rspec
     command: |
       mkdir -p test-results/rspec
-      TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=classname)
       bundle exec rspec --profile 10 \
         --format RspecJunitFormatter \
         --out test-results/rspec/results_${CIRCLE_NODE_INDEX}.xml \
-        --format progress \
-        -- ${TESTFILES}
+        --format progress
 
 version-setting: &version-setting
   run:
     name: Version Setting
     command: |
-      # 手動で変更した場合はmerge時messageに[tag release]をつける
-      commitmessage=$(git log --pretty=%B -n 1)
-      if [[ $commitmessage = *"[tag release]"* ]]; then
-        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-        # 環境変数として設定する必要あり
-        git config user.name $GIT_USER_NAME
-        git config user.email $GIT_USER_EMAIL
-        git tag $NEW_TAG
-        git push origin $NEW_TAG
-      else
-        OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-        NEW_TAG="${OLD_TAG%.*}"
-        NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-        ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-        echo $ALL_TEXT > lib/palette/elastic_search/version.rb
-        git config user.name $GIT_USER_NAME
-        git config user.email $GIT_USER_EMAIL
-        git add lib/palette/elastic_search/version.rb
-        git commit -m "[tag release] version up"
-        git push origin master
-      fi
-
-setting-build: &setting-build
-  steps:
-    - checkout
-    - save_cache:
-        key: *checkout_cache_key
-        paths: *working_directory
-    - *restore_bundle_cache
-    - *install-bundler
-    - *bundle-install
-    - save_cache:
-        key: *bundle_cache_key
-        paths:
-          - vendor/bundle
+      # # 手動で変更した場合はmerge時messageに[tag release]をつける
+      # commitmessage=$(git log --pretty=%B -n 1)
+      # if [[ $commitmessage = *"[tag release]"* ]]; then
+      #   NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      #   # 環境変数として設定する必要あり
+      #   git config user.name $GIT_USER_NAME
+      #   git config user.email $GIT_USER_EMAIL
+      #   git tag $NEW_TAG
+      #   git push origin $NEW_TAG
+      # else
+      #   OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      #   NEW_TAG="${OLD_TAG%.*}"
+      #   NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+      #   ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+      #   echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+      #   git config user.name $GIT_USER_NAME
+      #   git config user.email $GIT_USER_EMAIL
+      #   git add lib/palette/elastic_search/version.rb
+      #   git commit -m "[tag release] version up"
+      #   git push origin master
+      # fi
+      git config -l
+      git log --pretty=%B -n 1
 
 rspec-test: &rspec-test
   steps:
     - attach_workspace:
         at: .
     - checkout
-    - *restore_checkout_cache
-    - *restore_bundle_cache
-    - *install-bundler
     - *bundle_path
+    - *install-bundler
+    - *bundle-install
     - *run-rspec
     - store_test_results:
         path: test-results
@@ -107,16 +86,10 @@ release-tag: &release-tag
     - attach_workspace:
         at: .
     - checkout
-    - *restore_checkout_cache
-    - *restore_bundle_cache
     - *version-setting
 
 version: 2
 jobs:
-  build-setting:
-    <<: [*defaults, *deps-images]
-    <<: *setting-build
-
   test-rspec:
     <<: [*defaults, *deps-images]
     <<: *rspec-test
@@ -129,14 +102,7 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build-setting
       - test-rspec:
-          requires:
-            - build-setting
       - tag-release:
           requires:
-            - build-setting
             - test-rspec
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'circleci/ruby:2.4.2-jessie'
+    - image: 'quay.io/palettecloud/ruby-cron:v2.4.7'
       environment:
         TZ: Asia/Tokyo
 
@@ -46,15 +46,15 @@ tag-setting: &tag-setting
     command: |
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
-      git clone git@github.com:rei-akuto/palette-elastic_search.git
-      cd palette-elastic_search
+      # git clone git@github.com:rei-akuto/palette-elastic_search.git
+      # cd palette-elastic_search
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      git config user.name=$GIT_USER_NAME
-      git config user.email=$GIT_USER_EMAIL
+      # git config user.name=$GIT_USER_NAME
+      # git config user.email=$GIT_USER_EMAIL
       echo $GIT_USER_NAME
       echo $GIT_USER_EMAIL
-      git config -l
+      git branch -a
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ bundle-install: &bundle-install
     command: |
       bundle check --path vendor/bundle || bundle install --path vendor/bundle --quiet
 
-bundle_cache_key: &bundle_cache_key bundle-v1-{{ checksum "Gemfile.lock" }}
+bundle_cache_key: &bundle_cache_key bundle-v3-{{ checksum "Gemfile.lock" }}
 restore_bundle_cache: &restore_bundle_cache
   restore_cache:
     key: *bundle_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,21 +44,24 @@ tag-setting: &tag-setting
   run:
     name: Release Tag
     command: |
+      # version.rbが手動修正されている場合
       VERSION=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
       NEW_TAG=v${VERSION}
       echo $NEW_TAG
+      # 環境変数として設定する必要あり
       # git config user.name $GIT_USER_NAME
       # git config user.email $GIT_USER_EMAIL
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
 
-      # file自体書き換える場合
-      OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      NEW_TAG="${OLD_TAG%.*}"
-      NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-      echo $ALL_TEXT
+      # version.rbを自動修正する場合
+      # OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      # NEW_TAG="${OLD_TAG%.*}"
+      # NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+      # ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+      # echo $ALL_TEXT
       # echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+      # 環境変数として設定する必要あり
       # git config user.name $GIT_USER_NAME
       # git config user.email $GIT_USER_EMAIL
       # git add lib/palette/elastic_search/version.rb
@@ -128,6 +131,6 @@ workflows:
           requires:
             - build-setting
             - test-rspec
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ run-rspec: &run-rspec
         --format RspecJunitFormatter \
         --out test-results/rspec/results_${CIRCLE_NODE_INDEX}.xml \
         --format progress \
-        -- .
 
 version-setting: &version-setting
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ echo-tag: &echo-tag
     name: Echo Tag
     command: |
       echo $CIRCLE_TAG
+      echo 'test'
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ tag-setting: &tag-setting
       VERSION=$(grep -e V lib/palette/elastic_search/version.rb)
       arr=(`echo $VERSION`)
       NEW_TAG=${arr[2]}
-      echo NEW_TAG
+      echo $NEW_TAG
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
       # git tag $NEW_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'circleci/ruby:2.4.2-jessie-node'
+    - image: 'circleci/ruby:2.4.2-jessie'
       environment:
         TZ: Asia/Tokyo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,35 +50,27 @@ tag-setting: &tag-setting
   run:
     name: Release Tag
     command: |
-      # version.rbが手動修正されている場合
-      NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      # 環境変数として設定する必要あり
-      git config user.name $GIT_USER_NAME
-      git config user.email $GIT_USER_EMAIL
-      git tag $NEW_TAG
-      git push origin $NEW_TAG
-
-      # # version.rbを自動変更する場合
-      # # (メジャーバージョンは"手動変更かつmerge時commitに[tag-release]"または"マイナーバージョンを-1で設定"が必要)
-      # commitmessage=$(git log --pretty=%B -n 1)
-      # if [[ $commitmessage = *"[tag-release]"* ]]; then
-      #   NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      #   git config user.name $GIT_USER_NAME
-      #   git config user.email $GIT_USER_EMAIL
-      #   git tag $NEW_TAG
-      #   git push origin $NEW_TAG
-      # else
-      #   OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      #   NEW_TAG="${OLD_TAG%.*}"
-      #   NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      #   ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-      #   echo $ALL_TEXT > lib/palette/elastic_search/version.rb
-      #   git config user.name $GIT_USER_NAME
-      #   git config user.email $GIT_USER_EMAIL
-      #   git add lib/palette/elastic_search/version.rb
-      #   git commit -m "[tag-release]"
-      #   git push origin master
-      # fi
+      # 自動変更を望む場合はmerge時messageに[version_up]をつける
+      commitmessage=$(git log --pretty=%B -n 1)
+      if [[ $commitmessage = *"[version_up]"* ]]; then
+        OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        NEW_TAG="${OLD_TAG%.*}"
+        NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+        ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+        echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+        git config user.name $GIT_USER_NAME
+        git config user.email $GIT_USER_EMAIL
+        git add lib/palette/elastic_search/version.rb
+        git commit -m "verion auto up"
+        git push origin master
+      else
+        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        # 環境変数として設定する必要あり
+        git config user.name $GIT_USER_NAME
+        git config user.email $GIT_USER_EMAIL
+        git tag $NEW_TAG
+        git push origin $NEW_TAG
+      fi
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ tag-setting: &tag-setting
       git tag $NEW_TAG
       git push origin $NEW_TAG
 
-      # version.rbを自動修正する場合
+      # version.rbを自動修正する場合(全部マイナーバーションが更新されてしまうのでメジャーを変える場合-1,0等スタートが必要)
       # OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
       # NEW_TAG="${OLD_TAG%.*}"
       # NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
@@ -73,6 +73,8 @@ tag-setting: &tag-setting
       # git add lib/palette/elastic_search/version.rb
       # git commit -m "version up"
       # git push origin master
+      # git tag $NEW_TAG
+      # git push origin $NEW_TAG
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ echo-tag: &echo-tag
       TEST_TAG="v0.4.10"
       TEST="${TEST_TAG%.*}"
       TEST+="$((${TEST_TAG##*.} + 1))"
-      echo "${TEST_TAG}"
+      echo "${TEST}"
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,9 @@ echo-tag: &echo-tag
       # test="${CIRCLE_TAG%.*}"
       # test+="$((${CIRCLE_TAG##*.} + 1))"
       TEST_TAG="v0.4.10"
-      test="${TEST_TAG%.*}"
-      test+="$((${TEST_TAG##*.} + 1))"
+      TEST="${TEST_TAG%.*}"
+      TEST+="$((${TEST_TAG##*.} + 1))"
+      echo "${TEST_TAG}"
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,13 @@ tag-setting: &tag-setting
       git branch -a
       git config -l
 
+skip-ssh-command: &skip-ssh-command
+  run:
+    name: Skip ssh Command
+    command: |
+      mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+      
+
 
 setting-build: &setting-build
   steps:
@@ -86,9 +93,7 @@ rspec-test: &rspec-test
 
 release-tag: &release-tag
   steps:
-    - add_ssh_keys:
-        fingerprints:
-          - "a8:33:05:68:f8:e0:40:1b:45:7a:7c:1a:7b:3a:01:ce"
+    - *skip-ssh-command
     - *tag-setting
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ echo-tag: &echo-tag
   run:
     name: Echo Tag
     command: |
-      echo ${CIRCLE_TAG}
+      echo $CIRCLE_TAG
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,7 @@ tag-setting: &tag-setting
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      git config user.email "akutoyuuki@gmail.com"
-      git config user.name "rei-akuto"
-      git config -l
-      git log
+      git --version
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'quay.io/palettecloud/ruby-cron:v2.4.7'
+    - image: 'circleci/ruby:2.4.2-jessie-node'
       environment:
         TZ: Asia/Tokyo
 
@@ -48,12 +48,10 @@ tag-setting: &tag-setting
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
       git clone git@github.com:rei-akuto/palette-elastic_search.git
       cd palette-elastic_search
-      ls
-      pwd
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      git config user.name = $GIT_USER_NAME
-      git config user.email = $GIT_USER_EMAIL
+      git config user.name=$GIT_USER_NAME
+      git config user.email=$GIT_USER_EMAIL
       echo $GIT_USER_NAME
       echo $GIT_USER_EMAIL
       git config -l
@@ -88,6 +86,9 @@ rspec-test: &rspec-test
 
 release-tag: &release-tag
   steps:
+    - add_sh_keys:
+        fingerrints:
+          - "a8:33:05:68:f8:e0:40:1b:45:7a:7c:1a:7b:3a:01:ce"
     - *tag-setting
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ chenge-tag: &echo-tag
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      echo "test"
+      git log
+      git config -l
 
 setting-build: &setting-build
   steps:
@@ -106,6 +107,6 @@ workflows:
       - tag-setting:
           requires:
             - test-rspec
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ defaults: &defaults
 deps-images: &deps-images
   docker:
     - image: 'quay.io/palettecloud/ruby-cron:v2.4.7'
+      environment:
+        TZ: Asia/Tokyo
 
 bundle-install: &bundle-install
   run:
@@ -58,8 +60,6 @@ rspec-test: &rspec-test
     - *restore_checkout_cache
     - *restore_bundle_cache
     - *bundle_path
-    # restore_bundle_cacheができるまでの実験用
-    - *bundle-install
     - *run-rspec
     - store_test_results:
         path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,7 @@ echo-tag: &echo-tag
   run:
     name: Echo Tag
     command: |
-      echo $CIRCLE_TAG
-      echo 'test'
+      echo "${CIRCLE_TAG} test"
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ rspec-test: &rspec-test
 
 release-tag: &release-tag
   steps:
-    - add_sh_keys:
-        fingerrints:
+    - add_ssh_keys:
+        fingerprints:
           - "a8:33:05:68:f8:e0:40:1b:45:7a:7c:1a:7b:3a:01:ce"
     - *tag-setting
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,12 +47,21 @@ tag-setting: &tag-setting
       VERSION=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
       NEW_TAG=v${VERSION}
       echo $NEW_TAG
-      # NEW_TAG="${CIRCLE_TAG%.*}"
-      # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
+
+      # file自体書き換える場合
+      OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      NEW_TAG="${OLD_TAG%.*}"
+      NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+      OLD_TEXT=$(grep -e V lib/palette/elastic_search/version.rb)
+      NEW_TEXT=`echo $ALL_TEXT | sed s/$OLD_TAG/$NEW_TAG/g`
+      ALL_TEXT=$(sed s/$TEXT/$NEW_TEXT/ lib/palette/elastic_search/version.rb)
+      echo $ALL_TEXT
+      # echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+      # git add lib/palette/elastic_search/version.rb
+      # git commit -m "version up"
+      # git push origin master
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      # git config -l
-      # git branch -a
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ tag-setting: &tag-setting
     command: |
       VERSION=$(grep -e V lib/palette/elastic_search/version.rb)
       arr=(`echo $VERSION`)
-      NEW_TAG=${arr[2]}
+      NEW_TAG=v${arr[2]}
       echo $NEW_TAG
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,30 +51,12 @@ tag-setting: &tag-setting
     name: Release Tag
     command: |
       # version.rbが手動修正されている場合
-      VERSION=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      NEW_TAG=v${VERSION}
-      echo $NEW_TAG
+      NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
       # 環境変数として設定する必要あり
       git config user.name $GIT_USER_NAME
       git config user.email $GIT_USER_EMAIL
       git tag $NEW_TAG
       git push origin $NEW_TAG
-
-      # version.rbを自動修正する場合(全部マイナーバーションが更新されてしまうのでメジャーを変える場合-1,0等スタートが必要)
-      # OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      # NEW_TAG="${OLD_TAG%.*}"
-      # NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      # ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-      # echo $ALL_TEXT
-      # echo $ALL_TEXT > lib/palette/elastic_search/version.rb
-      # 環境変数として設定する必要あり
-      # git config user.name $GIT_USER_NAME
-      # git config user.email $GIT_USER_EMAIL
-      # git add lib/palette/elastic_search/version.rb
-      # git commit -m "version up"
-      # git push origin master
-      # git tag $NEW_TAG
-      # git push origin $NEW_TAG
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,16 @@ tag-setting: &tag-setting
   run:
     name: Release Tag
     command: |
-      # 自動変更を望む場合はmerge時messageに[version_up]をつける
+      # 手動で変更した場合はmerge時messageに[tag-release]をつける
       commitmessage=$(git log --pretty=%B -n 1)
-      if [[ $commitmessage = *"[version_up]"* ]]; then
+      if [[ $commitmessage = *"[tag-release]"* ]]; then
+        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        # 環境変数として設定する必要あり
+        git config user.name $GIT_USER_NAME
+        git config user.email $GIT_USER_EMAIL
+        git tag $NEW_TAG
+        git push origin $NEW_TAG
+      else
         OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
         NEW_TAG="${OLD_TAG%.*}"
         NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
@@ -61,15 +68,8 @@ tag-setting: &tag-setting
         git config user.name $GIT_USER_NAME
         git config user.email $GIT_USER_EMAIL
         git add lib/palette/elastic_search/version.rb
-        git commit -m "verion auto up"
+        git commit -m "[tag-release] version up"
         git push origin master
-      else
-        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-        # 環境変数として設定する必要あり
-        git config user.name $GIT_USER_NAME
-        git config user.email $GIT_USER_EMAIL
-        git tag $NEW_TAG
-        git push origin $NEW_TAG
       fi
 
 setting-build: &setting-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,16 +44,16 @@ tag-setting: &tag-setting
   run:
     name: Release Tag
     command: |
+      VERSION=$(grep -e V lib/palette/elastic_search/version.rb)
+      arr=(`echo $VERSION`)
+      NEW_TAG=${arr[2]}
+      echo NEW_TAG
       # NEW_TAG="${CIRCLE_TAG%.*}"
       # NEW_TAG+=".$((${CIRCLE_TAG##*.} + 1))"
-      # git clone git@github.com:machikoe/palette-elastic_search.git
-      # cd palette-elastic_search
-      # git config user.name=$GIT_USER_NAME
-      # git config user.email=$GIT_USER_EMAIL
       # git tag $NEW_TAG
       # git push origin $NEW_TAG
-      git config -l
-      git branch -a
+      # git config -l
+      # git branch -a
 
 setting-build: &setting-build
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ rspec-test: &rspec-test
     - attach_workspace:
         at: .
     - checkout
-    - *bundle_path
     - *install-bundler
+    - *bundle_path
     - *bundle-install
     - *run-rspec
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ setting-build: &setting-build
         key: *checkout_cache_key
         paths: *working_directory
     - *restore_bundle_cache
+    - *bundler-install
     - *bundle-install
     - save_cache:
         key: *bundle_cache_key
@@ -94,6 +95,7 @@ rspec-test: &rspec-test
     - checkout
     - *restore_checkout_cache
     - *restore_bundle_cache
+    - *bundler-install
     - *bundle_path
     - *run-rspec
     - store_test_results:
@@ -114,11 +116,11 @@ release-tag: &release-tag
 version: 2
 jobs:
   build-setting:
-    <<: [*defaults, *deps-images, *bundler-install]
+    <<: [*defaults, *deps-images]
     <<: *setting-build
 
   test-rspec:
-    <<: [*defaults, *deps-images, *bundler-install]
+    <<: [*defaults, *deps-images]
     <<: *rspec-test
 
   tag-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
 
 deps-images: &deps-images
   docker:
-    - image: 'circleci/ruby:2.7.0-node-browsers-legacy'
+    - image: 'circleci/ruby:2.7.0-node-browsers'
       environment:
         TZ: Asia/Tokyo
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/
@@ -9,6 +8,8 @@
 /tmp/
 /.idea
 /vendor/bundle
+
+.DS_Store
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    palette-elastic_search (0.4.10)
+    palette-elastic_search (0.4.11)
       activesupport
       elasticsearch-model (~> 5.0)
       elasticsearch-rails (~> 5.0)
@@ -34,10 +34,14 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.5)
     diff-lcs (1.3)
     elasticsearch (5.0.5)
@@ -56,6 +60,7 @@ GEM
     erubi (1.9.0)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.0)
     hashie (3.6.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
@@ -75,6 +80,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -113,18 +119,23 @@ GEM
     rspec-support (3.9.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    safe_yaml (1.0.5)
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activerecord
-  bundler (~> 1.17.3)
+  bundler (~> 2.0.1)
   palette-elastic_search!
   pry-rails
   rake (~> 10.0)
@@ -132,6 +143,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   sqlite3
+  webmock
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,137 @@
+PATH
+  remote: .
+  specs:
+    palette-elastic_search (0.4.10)
+      activesupport
+      elasticsearch-model (~> 5.0)
+      elasticsearch-rails (~> 5.0)
+      newrelic_rpm
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (5.2.3)
+      actionview (= 5.2.3)
+      activesupport (= 5.2.3)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.3)
+      activesupport (= 5.2.3)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
+      arel (>= 9.0)
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (9.0.0)
+    builder (3.2.3)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.5)
+    crass (1.0.5)
+    diff-lcs (1.3)
+    elasticsearch (5.0.5)
+      elasticsearch-api (= 5.0.5)
+      elasticsearch-transport (= 5.0.5)
+    elasticsearch-api (5.0.5)
+      multi_json
+    elasticsearch-model (5.1.0)
+      activesupport (> 3)
+      elasticsearch (~> 5)
+      hashie
+    elasticsearch-rails (5.1.0)
+    elasticsearch-transport (5.0.5)
+      faraday
+      multi_json
+    erubi (1.9.0)
+    faraday (0.17.0)
+      multipart-post (>= 1.2, < 3)
+    hashie (3.6.0)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.3.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    method_source (0.9.2)
+    mini_portile2 (2.4.0)
+    minitest (5.12.2)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
+    newrelic_rpm (6.7.0.359)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
+    rack (2.0.7)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
+    railties (5.2.3)
+      actionpack (= 5.2.3)
+      activesupport (= 5.2.3)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.19.0, < 2.0)
+    rake (10.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-rails (3.9.0)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    sqlite3 (1.4.1)
+    thor (0.20.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  bundler (~> 1.17.3)
+  palette-elastic_search!
+  pry-rails
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  rspec-rails
+  rspec_junit_formatter
+  sqlite3
+
+BUNDLED WITH
+   1.17.3

--- a/palette-elastic_search.gemspec
+++ b/palette-elastic_search.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'elasticsearch-model', '~> 5.0'
   spec.add_dependency 'newrelic_rpm'
 
-  spec.add_development_dependency 'bundler', '~> 1.17.3'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'

--- a/palette-elastic_search.gemspec
+++ b/palette-elastic_search.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-rails'
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'rspec_junit_formatter'
 end


### PR DESCRIPTION
## 概要
circle_ciの設定を作成する

## 要件
1. RSpecが実行できる
2. masterにマージすると、マイナーバージョン更新され、リリースタグが作成される(ex. 1.0.0 -> 1.0.1)

## 詳細
build→rspec→tag-release(masterのみ)の順で行われる

タグリリースを行うには環境変数として`$GIT_USER_NAME`, `$GIT_USER_NAME`の設定をする必要あり

version.rbは自動で変更される(マイナーバージョンが1増える)

version.rbを手動で変更する場合(メジャーバージョンを変更する時等)
 → merge時messageに`[tag release]`をつける

※circleciでのbundlerのバージョンが古いため`gem install bundler`している