### PR TITLE
searchに対してfind_in_batchesできるようにした

### DIFF
--- a/lib/palette/elastic_search.rb
+++ b/lib/palette/elastic_search.rb
@@ -11,6 +11,7 @@ module Palette
     autoload :QueryFactory, 'palette/elastic_search/query_factory'
     autoload :Configuration, 'palette/elastic_search/configuration'
     autoload :Indexing, 'palette/elastic_search/indexing'
+    autoload :Scrolling, 'palette/elastic_search/scrolling'
     autoload :Logger, 'palette/elastic_search/logger'
     autoload :NewRelicLoggingAdapter, 'palette/elastic_search/adapters/new_relic_logging_adapter'
     autoload :StdLoggingAdapter, 'palette/elastic_search/adapters/std_logging_adapter'

--- a/lib/palette/elastic_search.rb
+++ b/lib/palette/elastic_search.rb
@@ -16,6 +16,8 @@ module Palette
     autoload :NewRelicLoggingAdapter, 'palette/elastic_search/adapters/new_relic_logging_adapter'
     autoload :StdLoggingAdapter, 'palette/elastic_search/adapters/std_logging_adapter'
 
+    ::Elasticsearch::Model::Response::Response.__send__ :include, Scrolling
+
     def self.configuration
       Configuration.instance
     end

--- a/lib/palette/elastic_search/scrolling.rb
+++ b/lib/palette/elastic_search/scrolling.rb
@@ -1,0 +1,52 @@
+module Palette
+  module ElasticSearch
+    module Scrolling      
+      def self.included(base)
+        base.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def find_in_batches(batch_size: 1000)
+            scroll = '1m'
+            scroll_request = Class.new do
+              attr_reader :klass, :options
+      
+              def initialize(klass, options={})
+                @klass   = klass
+                @options = options
+      
+                unless @options[:scroll_id].present?
+                  raise ArgumentError, 'scroll_id is required.'
+                end
+              end
+      
+              def execute!
+                klass.client.scroll(@options)
+              end
+            end
+
+            self.search.definition.delete :scroll
+            self.search.definition.update size: batch_size
+      
+            unless block_given?
+              return to_enum(:find_in_batches, batch_size: batch_size) do
+                batch_size > 0 ? (self.results.total - 1) / batch_size + 1 : 0
+              end
+            end
+
+            self.search.definition.update scroll: scroll
+
+            response = self
+            pages_remain = batch_size > 0 ? (response.results.total - 1) / batch_size : 0
+            loop do
+              yield response
+              break unless pages_remain > 0
+
+              request = scroll_request.new(self.search.klass, scroll_id: response.response['_scroll_id'], scroll: scroll)
+              response = self.class.new(self.search.klass, request)
+              pages_remain -= 1
+            end
+          end
+        RUBY
+      end
+    end
+    ::Elasticsearch::Model::Response::Response.__send__ :include, Scrolling
+  end
+end

--- a/lib/palette/elastic_search/scrolling.rb
+++ b/lib/palette/elastic_search/scrolling.rb
@@ -24,7 +24,7 @@ module Palette
 
             self.search.definition.delete :scroll
             self.search.definition.update size: batch_size
-      
+
             unless block_given?
               return to_enum(:find_in_batches, batch_size: batch_size) do
                 batch_size > 0 ? (self.results.total - 1) / batch_size + 1 : 0
@@ -47,6 +47,5 @@ module Palette
         RUBY
       end
     end
-    ::Elasticsearch::Model::Response::Response.__send__ :include, Scrolling
   end
 end

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,5 +1,5 @@
 module Palette
   module ElasticSearch
-    VERSION = "0.4.10"
+    VERSION = "0.4.11"
   end
 end

--- a/palette-elastic_search.gemspec
+++ b/palette-elastic_search.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-rails'
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'webmock'
 end

--- a/spec/palette/elastic_search/scrolling_spec.rb
+++ b/spec/palette/elastic_search/scrolling_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+RSpec.describe Palette::ElasticSearch::Scrolling do
+  describe '.find_each' do
+    before do
+      allow(User.__elasticsearch__).to receive(:client).and_return Elasticsearch::Client.new(url: 'http://dummy-host')
+
+      # @note ESのレスポンス自体をstubしてテスト
+      search_stub
+      scroll_stub
+    end
+    let(:search_stub) do
+      stub_request(:get, "http://dummy-host/development_sample_database_users/user/_search?preference=_primary_first&scroll=1m&size=1")
+        .to_return(status: 200, body: search_stub_response.to_json, headers: {content_type: 'application/json'})
+    end
+    let(:scroll_stub) do
+      stub_request(:get, "http://dummy-host/_search/scroll?scroll=1m&scroll_id=DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAiWcWNkw0MXluZE9TWnF4UHJfRml6aVBDZw==")
+        .to_return(status: 200, body: scroll_stub_response.to_json, headers: {content_type: 'application/json'})
+    end
+    let(:search_stub_response) do
+      {
+        "_scroll_id": "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAiWcWNkw0MXluZE9TWnF4UHJfRml6aVBDZw==",
+        "took": 1,
+        "timed_out": false,
+        "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+        "hits": {
+          "total": total,
+          "max_score": 1.0,
+          "hits": [
+            {"_index": "development_sample_database_users", "_type": "user", "_id": "1", "_score": 1.0, "_source": {"id": "1"}}
+          ]
+        }
+      }
+    end
+    let(:scroll_stub_response) do
+      {
+        "_scroll_id": "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAiWcWNkw0MXluZE9TWnF4UHJfRml6aVBDZw==",
+        "took": 1,
+        "timed_out": false,
+        "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+        "hits": {
+          "total": total,
+          "max_score": 1.0,
+          "hits": [
+            {"_index": "development_sample_database_users", "_type": "user", "_id": "2", "_score": 1.0, "_source": {"id": "2"}}
+          ]
+        }
+      }
+    end
+    let(:total) { 1 }
+
+    context 'no results' do
+      let(:search_stub_response) do
+        {
+          "_scroll_id": "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAiWcWNkw0MXluZE9TWnF4UHJfRml6aVBDZw==",
+          "took": 1,
+          "timed_out": false,
+          "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+          "hits": {
+            "total": 0,
+            "max_score": 1.0,
+            "hits": []
+          }
+        }
+      end
+
+      it do
+        User.search({}).find_in_batches(batch_size: 1) do |response|
+          expect(response).to be_an_instance_of ::Elasticsearch::Model::Response::Response
+        end
+        expect(search_stub).to have_been_requested
+        expect(scroll_stub).not_to have_been_requested
+      end
+    end
+
+    context '1 page' do
+      let(:total) { 1 }
+
+      it do
+        User.search({}).find_in_batches(batch_size: 1) do |response|
+          expect(response).to be_an_instance_of ::Elasticsearch::Model::Response::Response
+        end
+        expect(search_stub).to have_been_requested
+        expect(scroll_stub).not_to have_been_requested
+      end
+    end
+
+    context '2 page' do
+      let(:total) { 2 }
+
+      it do
+        User.search({}).find_in_batches(batch_size: 1) do |response|
+          expect(response).to be_an_instance_of ::Elasticsearch::Model::Response::Response
+          # @note call api explicitly
+          response.response
+        end
+        expect(search_stub).to have_been_requested
+        expect(scroll_stub).to have_been_requested
+      end
+    end
+
+    context '3 page' do
+      let(:total) { 3 }
+
+      it do
+        User.search({}).find_in_batches(batch_size: 1) do |response|
+          expect(response).to be_an_instance_of ::Elasticsearch::Model::Response::Response
+          # @note call api explicitly
+          response.response
+        end
+        expect(search_stub).to have_been_requested
+        expect(scroll_stub).to have_been_requested.twice
+      end
+    end
+
+    context 'without block' do
+      let(:total) { 2 }
+
+      it do
+        User.search({}).find_in_batches(batch_size: 1).with_index do |response, index|
+          expect(response).to be_an_instance_of ::Elasticsearch::Model::Response::Response
+          # @note call api explicitly
+          response.response
+        end
+        expect(search_stub).to have_been_requested
+        expect(scroll_stub).to have_been_requested
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require 'webmock/rspec'
 require "palette/elastic_search"
 require 'pry'
 require 'user'


### PR DESCRIPTION
[scroll-api](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-request-scroll.html)を利用して結果の整合性を保ちながら全件取得してくれる `find_in_batches` を作った。
以下のように使える。

```
Person.search({}).find_in_batches(batch_size: 1000) do |response|
  puts response.records.records.pluck :identity_code
end
```

[kaminari](https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/response/pagination/kaminari.rb)の拡張を参考に `::Elasticsearch::Model::Response::Response` を拡張してみたのですがどうでしょう…。