### PR TITLE
自動version_upで改行されていない問題修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,24 +42,29 @@ version-setting: &version-setting
   run:
     name: Version Setting
     command: |
-      git config user.name $GIT_USER_NAME
-      git config user.email $GIT_USER_EMAIL
-      # 手動で変更した場合はmerge時messageに[tag release]をつける
-      commitmessage=$(git log --pretty=%B -n 1)
-      if [[ $commitmessage = *"[tag release]"* ]]; then
-        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-        git tag $NEW_TAG
-        git push origin $NEW_TAG
-      else
-        OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-        NEW_TAG="${OLD_TAG%.*}"
-        NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-        ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-        echo $ALL_TEXT > lib/palette/elastic_search/version.rb
-        git add lib/palette/elastic_search/version.rb
-        git commit -m "[ci skip] [tag release] version up"
-        git push origin master
-      fi
+      # git config user.name $GIT_USER_NAME
+      # git config user.email $GIT_USER_EMAIL
+      # # 手動で変更した場合はmerge時messageに[tag release]をつける
+      # commitmessage=$(git log --pretty=%B -n 1)
+      # if [[ $commitmessage = *"[tag release]"* ]]; then
+      #   NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      #   git tag $NEW_TAG
+      #   git push origin $NEW_TAG
+      # else
+      #   OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      #   NEW_TAG="${OLD_TAG%.*}"
+      #   NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+      #   ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+      #   echo $ALL_TEXT > lib/palette/elastic_search/version.rb
+      #   git add lib/palette/elastic_search/version.rb
+      #   git commit -m "[ci skip] [tag release] version up"
+      #   git push origin master
+      # fi
+      OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+      NEW_TAG="${OLD_TAG%.*}"
+      NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+      ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+      echo $ALL_TEXT
 
 rspec-test: &rspec-test
   steps:
@@ -101,6 +106,3 @@ workflows:
       - tag-release:
           requires:
             - test-rspec
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,29 +42,28 @@ version-setting: &version-setting
   run:
     name: Version Setting
     command: |
-      # git config user.name $GIT_USER_NAME
-      # git config user.email $GIT_USER_EMAIL
-      # # 手動で変更した場合はmerge時messageに[tag release]をつける
-      # commitmessage=$(git log --pretty=%B -n 1)
-      # if [[ $commitmessage = *"[tag release]"* ]]; then
-      #   NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      #   git tag $NEW_TAG
-      #   git push origin $NEW_TAG
-      # else
-      #   OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      #   NEW_TAG="${OLD_TAG%.*}"
-      #   NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      #   ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-      #   echo $ALL_TEXT > lib/palette/elastic_search/version.rb
-      #   git add lib/palette/elastic_search/version.rb
-      #   git commit -m "[ci skip] [tag release] version up"
-      #   git push origin master
-      # fi
-      OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
-      NEW_TAG="${OLD_TAG%.*}"
-      NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
-      ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
-      echo $ALL_TEXT
+      git config user.name $GIT_USER_NAME
+      git config user.email $GIT_USER_EMAIL
+      commitmessage=$(git log --pretty=%B -n 1)
+      if [[ $commitmessage = *"[skip release]"* ]]; then
+        # releaseしない場合は[skip release]をつける
+        echo "Skip Release"
+      elif [[ $commitmessage = *"[tag release]"* ]]; then
+        # 手動で変更した場合はmerge時messageに[tag release]をつける
+        NEW_TAG=v$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        git tag $NEW_TAG
+        git push origin $NEW_TAG
+      else
+        # その他はversion.rbを変更し際pushしてreleaseする
+        OLD_TAG=$(grep -e V lib/palette/elastic_search/version.rb | tr -d 'VERSION= "')
+        NEW_TAG="${OLD_TAG%.*}"
+        NEW_TAG+=".$((${OLD_TAG##*.} + 1))"
+        ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
+        echo "$ALL_TEXT" > lib/palette/elastic_search/version.rb
+        git add lib/palette/elastic_search/version.rb
+        git commit -m "[ci skip] [tag release] version up"
+        git push origin master
+      fi
 
 rspec-test: &rspec-test
   steps:
@@ -106,3 +105,6 @@ workflows:
       - tag-release:
           requires:
             - test-rspec
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ version-setting: &version-setting
         ALL_TEXT=$(sed s/$OLD_TAG/$NEW_TAG/ lib/palette/elastic_search/version.rb)
         echo "$ALL_TEXT" > lib/palette/elastic_search/version.rb
         git add lib/palette/elastic_search/version.rb
-        git commit -m "[ci skip] [tag release] version up"
+        git commit -m "[tag release] version up"
         git push origin master
       fi
 

--- a/lib/palette/elastic_search/version.rb
+++ b/lib/palette/elastic_search/version.rb
@@ -1,1 +1,5 @@
-module Palette module ElasticSearch VERSION = "0.4.12" end end
+module Palette
+  module ElasticSearch
+    VERSION = "0.4.11"
+  end
+end


### PR DESCRIPTION
## 概要
1. circleciでvesion.rbを自動変更すると改行されていない問題が存在したため修正する
2. releaseしない選択肢がなかったため追加する

※version.rbの中身を現在releaseされている最新のversionに戻しました

## 詳細
- version.rbを自動変更すると改行がなくなってしまう問題が見つかったため、正しく改行が維持されるよう修正しました

- release周りの選択肢について
  1. version.rb自動変更せずreleaseしない→merge時[skip release]記述
  2. version.rb自動変更せずreleaseする→merge時[tag release]記述
  3. version.rb自動変更してreleaseする→上記以外の場合


※自動変更してreleaseは自動でmasterにpushすることで実現しているため計2回ciが回ります
※version.rb自動変更してreleaseしない場合はない想定で選択肢に入れていません